### PR TITLE
fix: preserve files during mobile workspace import

### DIFF
--- a/e2e/features/conflict-resolution.feature
+++ b/e2e/features/conflict-resolution.feature
@@ -26,7 +26,7 @@ Feature: Conflict Resolution - Mobile and mock server concurrent edits
     And I tap the sync button for the first wiki workspace
     Then the sync should complete successfully
     And the mock server desktop git runner should be used
-    And the unsynced count should be zero after sync
+    And the workspace should have zero unsynced changes
     And the mock server tiddler "E2ETestTiddler.tid" body contains "Mock server conflict line."
     And the mock server tiddler "E2ETestTiddler.tid" body contains "Mobile conflict line."
     And the mock server tiddler "E2ETestTiddler.tid" header contains the mobile modified timestamp

--- a/e2e/features/desktop-sync.feature
+++ b/e2e/features/desktop-sync.feature
@@ -22,6 +22,7 @@ Feature: Desktop Sync - Import, create changes, and sync wiki through the local 
     And I tap the import wiki confirm button
     Then the import should complete successfully
     And I should see the imported wiki in the workspace list
+    And the imported wiki should have zero unsynced changes
 
   # ── Open ──────────────────────────────────────────────────────────────────────
 

--- a/e2e/features/desktop-sync.feature
+++ b/e2e/features/desktop-sync.feature
@@ -22,7 +22,7 @@ Feature: Desktop Sync - Import, create changes, and sync wiki through the local 
     And I tap the import wiki confirm button
     Then the import should complete successfully
     And I should see the imported wiki in the workspace list
-    And the imported wiki should have zero unsynced changes
+    And the workspace should have zero unsynced changes
 
   # ── Open ──────────────────────────────────────────────────────────────────────
 
@@ -57,4 +57,4 @@ Feature: Desktop Sync - Import, create changes, and sync wiki through the local 
     And a test tiddler is written to the first wiki via adb
     When I tap the sync button for the first wiki workspace
     Then the sync should complete successfully
-    And the unsynced count should be zero after sync
+    And the workspace should have zero unsynced changes

--- a/e2e/mock-server/setup.ts
+++ b/e2e/mock-server/setup.ts
@@ -187,6 +187,11 @@ export function writeBaselineWikiFiles(): void {
     ),
     'utf8',
   );
+  // Regression fixture for Windows repositories. Archive imports must
+  // preserve this committed CRLF blob instead of immediately reporting it as
+  // a dirty working-tree file.
+  writeFileSync(join(TEST_WIKI_DIR, '.gitattributes'), 'windows-crlf.md -text\n', 'utf8');
+  writeFileSync(join(TEST_WIKI_DIR, 'windows-crlf.md'), 'first line\r\nsecond line\r\n', 'utf8');
 
   putTid('$__StoryList.tid', ['title: $:/StoryList', 'list:', '']);
   putTid('HelloThere.tid', ['title: HelloThere', 'type: text/vnd.tiddlywiki', '', 'E2E mock wiki.']);

--- a/e2e/stepDefinitions/desktopSync.steps.ts
+++ b/e2e/stepDefinitions/desktopSync.steps.ts
@@ -17,6 +17,7 @@ import { diagnosticError, dismissBlockingAlert, isAlertShowing, waitForElement }
 
 const UI_TIMEOUT = 10_000;
 const NETWORK_TIMEOUT = 120_000;
+const APP_PACKAGE = 'ren.onetwo.tidgi.mobile.test';
 const configuredDesktopUrl: unknown = process.env.TIDGI_DESKTOP_URL;
 const realDesktopUrl = typeof configuredDesktopUrl === 'string' ? configuredDesktopUrl : undefined;
 const configuredDesktopQrJson: unknown = process.env.TIDGI_DESKTOP_QR_JSON;
@@ -125,8 +126,7 @@ async function tapImportWikiConfirmButton(): Promise<void> {
   } catch {
     // A real Desktop payload can include multiple sub-workspaces, pushing the
     // button below the physical device viewport.
-    await element(by.id('importer-screen')).swipe('up', 'fast', 0.75);
-    await delay(750);
+    await element(by.id('importer-screen')).scrollTo('bottom');
     await waitFor(element(by.id('import-wiki-confirm-button'))).toBeVisible().withTimeout(UI_TIMEOUT);
   }
   await element(by.id('import-wiki-confirm-button')).tap();
@@ -249,56 +249,51 @@ async function createTiddlerViaWikiWebView(title: string): Promise<void> {
 }
 
 // ── Sync ──────────────────────────────────────────────────────────────────────
+interface IPersistedWikiWorkspace {
+  id?: string;
+  syncedServers?: Array<{ serverID?: string }>;
+  type?: string;
+  wikiFolderLocation?: string;
+}
+
+function readPersistedWikiWorkspaces(): IPersistedWikiWorkspace[] {
+  const storagePath = `/data/data/${APP_PACKAGE}/files/persistStorage/wiki-storage`;
+  const raw = execSync(`adb shell run-as ${APP_PACKAGE} cat ${storagePath}`, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+  });
+  const parsed = JSON.parse(raw) as { state?: { workspaces?: IPersistedWikiWorkspace[] } };
+  return parsed.state?.workspaces?.filter(workspace => workspace.type === 'wiki') ?? [];
+}
+
+function selectImportedWikiWorkspace(): IPersistedWikiWorkspace | undefined {
+  const wikiList = readPersistedWikiWorkspaces();
+  return wikiList.find(workspace => workspace.id === 'standalone') ??
+    wikiList.find(workspace => workspace.syncedServers?.some(server => typeof server.serverID === 'string' && server.serverID.length > 0) === true) ??
+    wikiList[0];
+}
+
+function listWikiDirectoryIds(): string[] {
+  const wikiRoot = `/data/data/${APP_PACKAGE}/files/wikis`;
+  const raw = execSync(`adb shell run-as ${APP_PACKAGE} ls ${wikiRoot}`, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+  }).trim();
+  return raw.split(/\r?\n/).map(value => value.trim()).filter(value => value.length > 0);
+}
+
 function getImportedWikiWorkspaceId(): string | undefined {
   try {
-    const raw = execSync('adb shell run-as ren.onetwo.tidgi.mobile.test cat /data/data/ren.onetwo.tidgi.mobile.test/files/persistStorage/wiki-storage', {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    });
-    const parsed = JSON.parse(raw) as {
-      state?: {
-        workspaces?: Array<{
-          id?: string;
-          type?: string;
-          syncedServers?: Array<{ serverID?: string }>;
-        }>;
-      };
-    };
-    const wikiList = parsed.state?.workspaces?.filter(w => w.type === 'wiki') ?? [];
-    const standaloneWiki = wikiList.find(w => w.id === 'standalone');
-    if (standaloneWiki?.id) return standaloneWiki.id;
-    const importedWiki = wikiList.find(w => Array.isArray(w.syncedServers) && w.syncedServers.some(server => typeof server.serverID === 'string' && server.serverID.length > 0));
-    if (importedWiki?.id) return importedWiki.id;
-    return wikiList[0]?.id;
+    return selectImportedWikiWorkspace()?.id;
   } catch {
-    const raw = execSync('adb shell run-as ren.onetwo.tidgi.mobile.test ls /data/data/ren.onetwo.tidgi.mobile.test/files/wikis', {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    }).trim();
-    const ids = raw.split(/\r?\n/).map(s => s.trim()).filter(s => s.length > 0);
+    const ids = listWikiDirectoryIds();
     return ids.find(id => id === 'standalone') ?? ids[0];
   }
 }
 
 function getImportedWikiWorkspacePath(): string {
   try {
-    const raw = execSync('adb shell run-as ren.onetwo.tidgi.mobile.test cat /data/data/ren.onetwo.tidgi.mobile.test/files/persistStorage/wiki-storage', {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    });
-    const parsed = JSON.parse(raw) as {
-      state?: {
-        workspaces?: Array<{
-          id?: string;
-          type?: string;
-          wikiFolderLocation?: string;
-          syncedServers?: Array<{ serverID?: string }>;
-        }>;
-      };
-    };
-    const wikiList = parsed.state?.workspaces?.filter(w => w.type === 'wiki' && typeof w.wikiFolderLocation === 'string') ?? [];
-    const standaloneWiki = wikiList.find(w => w.id === 'standalone');
-    const importedWiki = standaloneWiki ?? wikiList.find(w => Array.isArray(w.syncedServers) && w.syncedServers.some(server => typeof server.serverID === 'string' && server.serverID.length > 0)) ?? wikiList[0];
+    const importedWiki = selectImportedWikiWorkspace();
     if (typeof importedWiki?.wikiFolderLocation === 'string') {
       return importedWiki.wikiFolderLocation.replace(/^file:\/\//, '').replace(/\/$/, '');
     }
@@ -306,15 +301,11 @@ function getImportedWikiWorkspacePath(): string {
     // Fall back to the first wiki directory below.
   }
 
-  const raw = execSync('adb shell run-as ren.onetwo.tidgi.mobile.test ls /data/data/ren.onetwo.tidgi.mobile.test/files/wikis', {
-    encoding: 'utf8',
-    stdio: ['pipe', 'pipe', 'ignore'],
-  }).trim();
-  const fallbackId = raw.split(/\r?\n/).map(value => value.trim()).find(value => value.length > 0);
+  const fallbackId = listWikiDirectoryIds()[0];
   if (!fallbackId) {
     throw new Error('No imported wiki workspace path found on device.');
   }
-  return `/data/data/ren.onetwo.tidgi.mobile.test/files/wikis/${fallbackId}`;
+  return `/data/data/${APP_PACKAGE}/files/wikis/${fallbackId}`;
 }
 
 function writeMobileTiddlerViaAdb(wikiPath: string, tiddlerFilename: string, content: string): void {
@@ -325,7 +316,7 @@ function writeMobileTiddlerViaAdb(wikiPath: string, tiddlerFilename: string, con
   writeFileSync(hostTemporary, content, 'utf8');
   execSync(`adb push "${hostTemporary}" "${deviceTemporary}"`, { stdio: 'ignore', timeout: 15_000 });
   execSync(
-    `adb shell "run-as ren.onetwo.tidgi.mobile.test sh -c 'mkdir -p \"${wikiPath}/tiddlers\" && cp \"${deviceTemporary}\" \"${devicePath}\"'"`,
+    `adb shell "run-as ${APP_PACKAGE} sh -c 'mkdir -p \"${wikiPath}/tiddlers\" && cp \"${deviceTemporary}\" \"${devicePath}\"'"`,
     { stdio: 'ignore', timeout: 15_000 },
   );
 }
@@ -419,15 +410,11 @@ async function waitForSyncSuccess(maxWaitMs = NETWORK_TIMEOUT): Promise<void> {
   throw diagnosticError(successId, maxWaitMs);
 }
 
-Then('the unsynced count should be zero after sync', async () => {
-  await assertUnsyncedCountIsZero();
+Then('the workspace should have zero unsynced changes', async () => {
+  await assertWorkspaceHasNoUnsyncedChanges();
 });
 
-Then('the imported wiki should have zero unsynced changes', async () => {
-  await assertUnsyncedCountIsZero();
-});
-
-async function assertUnsyncedCountIsZero(): Promise<void> {
+async function assertWorkspaceHasNoUnsyncedChanges(): Promise<void> {
   const wikiId = getImportedWikiWorkspaceId();
   if (!wikiId) throw new Error('No wiki workspace found.');
   await element(by.id(`workspace-settings-icon-${wikiId}`)).tap();
@@ -498,6 +485,6 @@ Given('the imported mock server wiki has a synced tiddler {string} in shared his
   await delay(5_000);
   await tapSyncButtonForImportedWiki();
   await waitForSyncSuccess();
-  await assertUnsyncedCountIsZero();
+  await assertWorkspaceHasNoUnsyncedChanges();
   assertMockServerGitWorkingTreeContains(title);
 });

--- a/e2e/stepDefinitions/desktopSync.steps.ts
+++ b/e2e/stepDefinitions/desktopSync.steps.ts
@@ -7,16 +7,21 @@
  */
 import { Given, Then, When } from '@cucumber/cucumber';
 import { execSync } from 'child_process';
+import { by, device, element, waitFor } from 'detox';
+import { readFileSync, writeFileSync } from 'fs';
+import { get as httpGet } from 'node:http';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { readFileSync, writeFileSync } from 'fs';
-import { by, device, element, waitFor } from 'detox';
-import { get as httpGet } from 'node:http';
 import { getDesktopGitRunnerHitsPath, getMockServerUrl, getTestWikiDirectory } from '../mock-server/setup';
 import { diagnosticError, dismissBlockingAlert, isAlertShowing, waitForElement } from '../support/diagnostics';
 
 const UI_TIMEOUT = 10_000;
 const NETWORK_TIMEOUT = 120_000;
+const configuredDesktopUrl: unknown = process.env.TIDGI_DESKTOP_URL;
+const realDesktopUrl = typeof configuredDesktopUrl === 'string' ? configuredDesktopUrl : undefined;
+// A multi-gigabyte workspace can spend more than ten minutes rebuilding its
+// JGit index on a physical device after the archive has been extracted.
+const IMPORT_TIMEOUT = realDesktopUrl === undefined ? NETWORK_TIMEOUT : 30 * 60_000;
 const delay = (ms = 1_000) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
 function adbKeyEvent(key: number): void {
@@ -43,8 +48,8 @@ async function navigateToImporterScreen(): Promise<void> {
   await waitForElement(by.id('importer-screen'), 10_000, 'importer-screen');
 }
 
-async function assertMockServerReachable(): Promise<void> {
-  const url = getMockServerUrl();
+async function assertSyncServerReachable(): Promise<void> {
+  const url = realDesktopUrl ?? getMockServerUrl();
   // The mock server is started without TiddlyWeb Basic Auth so the mobile
   // client can access Git endpoints anonymously. We just check /status is up.
   const statusCode = await new Promise<number>((resolve, reject) => {
@@ -62,7 +67,7 @@ async function assertMockServerReachable(): Promise<void> {
   }
 }
 
-async function enterMockServerUrl(): Promise<void> {
+async function enterSyncServerUrl(): Promise<void> {
   // Open the manual JSON configuration panel if it is not already open.
   try {
     await waitFor(element(by.id('toggle-manual-config-button'))).toExist().withTimeout(2_000);
@@ -73,13 +78,31 @@ async function enterMockServerUrl(): Promise<void> {
   }
 
   await waitForElement(by.id('manual-json-input'), UI_TIMEOUT, 'manual-json-input');
-  const url = getMockServerUrl();
-  const qrPayload = JSON.stringify({
-    baseUrl: url,
-    workspaceId: 'standalone',
-    workspaceName: 'E2E Mock Wiki',
-    useStandardGitProtocol: false,
-  });
+  const url = realDesktopUrl ?? getMockServerUrl();
+  const qrPayload = realDesktopUrl === undefined
+    ? JSON.stringify({
+      baseUrl: url,
+      workspaceId: 'standalone',
+      workspaceName: 'E2E Mock Wiki',
+      useStandardGitProtocol: false,
+    })
+    : await new Promise<string>((resolve, reject) => {
+      const request = httpGet(`${url}/tw-mobile-sync/git/mobile-sync-info`, response => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk: Buffer) => chunks.push(chunk));
+        response.on('end', () => {
+          if (response.statusCode !== 200) {
+            reject(new Error(`Failed to fetch mobile sync info from ${url} (HTTP ${response.statusCode ?? 0})`));
+            return;
+          }
+          resolve(Buffer.concat(chunks).toString('utf8'));
+        });
+      });
+      request.setTimeout(10_000, () => {
+        request.destroy(new Error(`Timed out fetching mobile sync info from ${url}`));
+      });
+      request.on('error', reject);
+    });
   await element(by.id('manual-json-input')).clearText();
   await element(by.id('manual-json-input')).typeText(qrPayload);
 
@@ -94,10 +117,19 @@ async function enterMockServerUrl(): Promise<void> {
 
 async function tapImportWikiConfirmButton(): Promise<void> {
   await waitForElement(by.id('import-wiki-confirm-button'), UI_TIMEOUT, 'import-wiki-confirm-button');
+  try {
+    await waitFor(element(by.id('import-wiki-confirm-button'))).toBeVisible().withTimeout(1_000);
+  } catch {
+    // A real Desktop payload can include multiple sub-workspaces, pushing the
+    // button below the physical device viewport.
+    execSync('adb shell input swipe 540 1850 540 500 500', { stdio: 'ignore', timeout: 3_000 });
+    await delay(750);
+    await waitFor(element(by.id('import-wiki-confirm-button'))).toBeVisible().withTimeout(UI_TIMEOUT);
+  }
   await element(by.id('import-wiki-confirm-button')).tap();
 }
 
-async function waitForImportSuccess(maxWaitMs = NETWORK_TIMEOUT): Promise<void> {
+async function waitForImportSuccess(maxWaitMs = IMPORT_TIMEOUT): Promise<void> {
   const start = Date.now();
   const pollInterval = 1_500;
 
@@ -145,8 +177,8 @@ async function waitForImportedWikiInWorkspaceList(): Promise<void> {
 
 async function importFreshMockServerWiki(): Promise<void> {
   await navigateToImporterScreen();
-  await assertMockServerReachable();
-  await enterMockServerUrl();
+  await assertSyncServerReachable();
+  await enterSyncServerUrl();
   await tapImportWikiConfirmButton();
   await waitForImportSuccess();
   await waitForImportedWikiInWorkspaceList();
@@ -162,18 +194,18 @@ Then('I should see the importer screen', async () => {
 });
 
 Then('the mock server is reachable', { timeout: 30_000 }, async () => {
-  await assertMockServerReachable();
+  await assertSyncServerReachable();
 });
 
 When('I enter the mock server URL', async () => {
-  await enterMockServerUrl();
+  await enterSyncServerUrl();
 });
 
 When('I tap the import wiki confirm button', async () => {
   await tapImportWikiConfirmButton();
 });
 
-Then('the import should complete successfully', { timeout: NETWORK_TIMEOUT + 30_000 }, async () => {
+Then('the import should complete successfully', { timeout: IMPORT_TIMEOUT + 30_000 }, async () => {
   await waitForImportSuccess();
 });
 

--- a/e2e/stepDefinitions/desktopSync.steps.ts
+++ b/e2e/stepDefinitions/desktopSync.steps.ts
@@ -19,6 +19,8 @@ const UI_TIMEOUT = 10_000;
 const NETWORK_TIMEOUT = 120_000;
 const configuredDesktopUrl: unknown = process.env.TIDGI_DESKTOP_URL;
 const realDesktopUrl = typeof configuredDesktopUrl === 'string' ? configuredDesktopUrl : undefined;
+const configuredDesktopQrJson: unknown = process.env.TIDGI_DESKTOP_QR_JSON;
+const realDesktopQrJson = typeof configuredDesktopQrJson === 'string' ? configuredDesktopQrJson : undefined;
 // A multi-gigabyte workspace can spend more than ten minutes rebuilding its
 // JGit index on a physical device after the archive has been extracted.
 const IMPORT_TIMEOUT = realDesktopUrl === undefined ? NETWORK_TIMEOUT : 30 * 60_000;
@@ -62,8 +64,9 @@ async function assertSyncServerReachable(): Promise<void> {
     });
     request.on('error', reject);
   });
-  if (statusCode !== 200 && statusCode !== 204) {
-    throw new Error(`Mock server not reachable at ${url}/status (HTTP ${statusCode})`);
+  const isReachable = realDesktopUrl === undefined ? statusCode === 200 || statusCode === 204 : statusCode >= 200 && statusCode < 500;
+  if (!isReachable) {
+    throw new Error(`Sync server not reachable at ${url}/status (HTTP ${statusCode})`);
   }
 }
 
@@ -86,7 +89,7 @@ async function enterSyncServerUrl(): Promise<void> {
       workspaceName: 'E2E Mock Wiki',
       useStandardGitProtocol: false,
     })
-    : await new Promise<string>((resolve, reject) => {
+    : realDesktopQrJson ?? await new Promise<string>((resolve, reject) => {
       const request = httpGet(`${url}/tw-mobile-sync/git/mobile-sync-info`, response => {
         const chunks: Buffer[] = [];
         response.on('data', (chunk: Buffer) => chunks.push(chunk));
@@ -122,7 +125,7 @@ async function tapImportWikiConfirmButton(): Promise<void> {
   } catch {
     // A real Desktop payload can include multiple sub-workspaces, pushing the
     // button below the physical device viewport.
-    execSync('adb shell input swipe 540 1850 540 500 500', { stdio: 'ignore', timeout: 3_000 });
+    await element(by.id('importer-screen')).swipe('up', 'fast', 0.75);
     await delay(750);
     await waitFor(element(by.id('import-wiki-confirm-button'))).toBeVisible().withTimeout(UI_TIMEOUT);
   }

--- a/e2e/stepDefinitions/desktopSync.steps.ts
+++ b/e2e/stepDefinitions/desktopSync.steps.ts
@@ -9,7 +9,8 @@ import { Given, Then, When } from '@cucumber/cucumber';
 import { execSync } from 'child_process';
 import { by, device, element, waitFor } from 'detox';
 import { readFileSync, writeFileSync } from 'fs';
-import { get as httpGet } from 'node:http';
+import { ClientRequest, get as httpGet, IncomingMessage } from 'node:http';
+import { get as httpsGet } from 'node:https';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { getDesktopGitRunnerHitsPath, getMockServerUrl, getTestWikiDirectory } from '../mock-server/setup';
@@ -28,6 +29,10 @@ const realDesktopQrJson = nonEmptyEnvironmentValue(process.env.TIDGI_DESKTOP_QR_
 // JGit index on a physical device after the archive has been extracted.
 const IMPORT_TIMEOUT = realDesktopUrl === undefined ? NETWORK_TIMEOUT : 30 * 60_000;
 const delay = (ms = 1_000) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+function getUrl(url: string, callback: (response: IncomingMessage) => void): ClientRequest {
+  return new URL(url).protocol === 'https:' ? httpsGet(url, callback) : httpGet(url, callback);
+}
 
 function adbKeyEvent(key: number): void {
   try {
@@ -58,7 +63,7 @@ async function assertSyncServerReachable(): Promise<void> {
   // The mock server is started without TiddlyWeb Basic Auth so the mobile
   // client can access Git endpoints anonymously. We just check /status is up.
   const statusCode = await new Promise<number>((resolve, reject) => {
-    const request = httpGet(`${url}/status`, response => {
+    const request = getUrl(`${url}/status`, response => {
       response.resume();
       resolve(response.statusCode ?? 0);
     });
@@ -93,7 +98,7 @@ async function enterSyncServerUrl(): Promise<void> {
       useStandardGitProtocol: false,
     })
     : realDesktopQrJson ?? await new Promise<string>((resolve, reject) => {
-      const request = httpGet(`${url}/tw-mobile-sync/git/mobile-sync-info`, response => {
+      const request = getUrl(`${url}/tw-mobile-sync/git/mobile-sync-info`, response => {
         const chunks: Buffer[] = [];
         response.on('data', (chunk: Buffer) => chunks.push(chunk));
         response.on('end', () => {

--- a/e2e/stepDefinitions/desktopSync.steps.ts
+++ b/e2e/stepDefinitions/desktopSync.steps.ts
@@ -423,12 +423,21 @@ Then('the unsynced count should be zero after sync', async () => {
   await assertUnsyncedCountIsZero();
 });
 
+Then('the imported wiki should have zero unsynced changes', async () => {
+  await assertUnsyncedCountIsZero();
+});
+
 async function assertUnsyncedCountIsZero(): Promise<void> {
   const wikiId = getImportedWikiWorkspaceId();
   if (!wikiId) throw new Error('No wiki workspace found.');
   await element(by.id(`workspace-settings-icon-${wikiId}`)).tap();
   await waitForElement(by.id('workspace-detail-screen'), 30_000, 'workspace-detail-screen');
   await waitForElement(by.id('workspace-unsynced-count'), 30_000, 'workspace-unsynced-count');
+  const attributes = await element(by.id('workspace-unsynced-count')).getAttributes();
+  const countText = Array.isArray(attributes) ? undefined : (attributes as { text?: unknown }).text;
+  if (typeof countText !== 'string' || !/^0(?:\s|$)/.test(countText)) {
+    throw new Error(`Expected zero unsynced changes, received ${JSON.stringify(countText)}`);
+  }
   try {
     await device.pressBack();
   } catch {

--- a/e2e/stepDefinitions/desktopSync.steps.ts
+++ b/e2e/stepDefinitions/desktopSync.steps.ts
@@ -18,10 +18,12 @@ import { diagnosticError, dismissBlockingAlert, isAlertShowing, waitForElement }
 const UI_TIMEOUT = 10_000;
 const NETWORK_TIMEOUT = 120_000;
 const APP_PACKAGE = 'ren.onetwo.tidgi.mobile.test';
-const configuredDesktopUrl: unknown = process.env.TIDGI_DESKTOP_URL;
-const realDesktopUrl = typeof configuredDesktopUrl === 'string' ? configuredDesktopUrl : undefined;
-const configuredDesktopQrJson: unknown = process.env.TIDGI_DESKTOP_QR_JSON;
-const realDesktopQrJson = typeof configuredDesktopQrJson === 'string' ? configuredDesktopQrJson : undefined;
+const nonEmptyEnvironmentValue = (value: string | undefined): string | undefined => {
+  const trimmedValue = value?.trim();
+  return trimmedValue === undefined || trimmedValue.length === 0 ? undefined : trimmedValue;
+};
+const realDesktopUrl = nonEmptyEnvironmentValue(process.env.TIDGI_DESKTOP_URL);
+const realDesktopQrJson = nonEmptyEnvironmentValue(process.env.TIDGI_DESKTOP_QR_JSON);
 // A multi-gigabyte workspace can spend more than ten minutes rebuilding its
 // JGit index on a physical device after the archive has been extracted.
 const IMPORT_TIMEOUT = realDesktopUrl === undefined ? NETWORK_TIMEOUT : 30 * 60_000;
@@ -121,14 +123,22 @@ async function enterSyncServerUrl(): Promise<void> {
 
 async function tapImportWikiConfirmButton(): Promise<void> {
   await waitForElement(by.id('import-wiki-confirm-button'), UI_TIMEOUT, 'import-wiki-confirm-button');
-  try {
-    await waitFor(element(by.id('import-wiki-confirm-button'))).toBeVisible().withTimeout(1_000);
-  } catch {
-    // A real Desktop payload can include multiple sub-workspaces, pushing the
-    // button below the physical device viewport.
-    await element(by.id('importer-screen')).scrollTo('bottom');
-    await waitFor(element(by.id('import-wiki-confirm-button'))).toBeVisible().withTimeout(UI_TIMEOUT);
+  let isVisible = false;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await waitFor(element(by.id('import-wiki-confirm-button'))).toBeVisible().withTimeout(1_000);
+      isVisible = true;
+      break;
+    } catch {
+      // A real Desktop payload can include multiple sub-workspaces, pushing
+      // the button below the physical device viewport. Detox scrollToEdge
+      // repeatedly injects gestures on some JOYUI devices and can disconnect
+      // UiAutomation, so use a bounded number of ordinary swipes instead.
+      await element(by.id('importer-screen')).swipe('up', 'fast', 0.6);
+      await delay(500);
+    }
   }
+  if (!isVisible) throw new Error('Import wiki confirm button did not become visible after scrolling');
   await element(by.id('import-wiki-confirm-button')).tap();
 }
 
@@ -172,10 +182,11 @@ async function waitForImportedWikiInWorkspaceList(): Promise<void> {
   await navigateBackToMainMenuScreen();
   await delay(3_000);
 
-  // The sync button has a per-workspace testID; locate the imported wiki first.
+  // Assert the workspace card itself. The sync button testID depends on
+  // whether this workspace has already recorded a successful sync.
   const wikiId = getImportedWikiWorkspaceId();
   if (!wikiId) throw new Error('No imported wiki found in device storage.');
-  await waitForElement(by.id(`sync-icon-button-${wikiId}`), 20_000, `sync-icon-button-${wikiId}`);
+  await waitForElement(by.id(`workspace-item-${wikiId}`), 20_000, `workspace-item-${wikiId}`);
 }
 
 async function importFreshMockServerWiki(): Promise<void> {
@@ -251,6 +262,9 @@ async function createTiddlerViaWikiWebView(title: string): Promise<void> {
 // ── Sync ──────────────────────────────────────────────────────────────────────
 interface IPersistedWikiWorkspace {
   id?: string;
+  isSubWiki?: boolean;
+  mainWikiID?: string | null;
+  name?: string;
   syncedServers?: Array<{ serverID?: string }>;
   type?: string;
   wikiFolderLocation?: string;
@@ -268,8 +282,11 @@ function readPersistedWikiWorkspaces(): IPersistedWikiWorkspace[] {
 
 function selectImportedWikiWorkspace(): IPersistedWikiWorkspace | undefined {
   const wikiList = readPersistedWikiWorkspaces();
-  return wikiList.find(workspace => workspace.id === 'standalone') ??
-    wikiList.find(workspace => workspace.syncedServers?.some(server => typeof server.serverID === 'string' && server.serverID.length > 0) === true) ??
+  const hasSyncServer = (workspace: IPersistedWikiWorkspace): boolean =>
+    workspace.syncedServers?.some(server => typeof server.serverID === 'string' && server.serverID.length > 0) === true;
+  return wikiList.find(workspace => workspace.isSubWiki !== true && hasSyncServer(workspace)) ??
+    wikiList.find(workspace => workspace.id === 'standalone') ??
+    wikiList.find(hasSyncServer) ??
     wikiList[0];
 }
 
@@ -410,27 +427,72 @@ async function waitForSyncSuccess(maxWaitMs = NETWORK_TIMEOUT): Promise<void> {
   throw diagnosticError(successId, maxWaitMs);
 }
 
-Then('the workspace should have zero unsynced changes', async () => {
-  await assertWorkspaceHasNoUnsyncedChanges();
+Then('the workspace should have zero unsynced changes', { timeout: 10 * 60_000 }, async () => {
+  await assertImportedWorkspacesHaveNoUnsyncedChanges();
 });
 
-async function assertWorkspaceHasNoUnsyncedChanges(): Promise<void> {
-  const wikiId = getImportedWikiWorkspaceId();
-  if (!wikiId) throw new Error('No wiki workspace found.');
-  await element(by.id(`workspace-settings-icon-${wikiId}`)).tap();
+async function assertCurrentWorkspaceHasNoUnsyncedChanges(workspace: IPersistedWikiWorkspace): Promise<void> {
   await waitForElement(by.id('workspace-detail-screen'), 30_000, 'workspace-detail-screen');
-  await waitForElement(by.id('workspace-unsynced-count'), 30_000, 'workspace-unsynced-count');
+  await waitForElement(by.id('workspace-unsynced-count'), 120_000, 'workspace-unsynced-count');
   const attributes = await element(by.id('workspace-unsynced-count')).getAttributes();
   const countText = Array.isArray(attributes) ? undefined : (attributes as { text?: unknown }).text;
   if (typeof countText !== 'string' || !/^0(?:\s|$)/.test(countText)) {
-    throw new Error(`Expected zero unsynced changes, received ${JSON.stringify(countText)}`);
+    throw new Error(`Expected zero unsynced changes for ${workspace.name ?? workspace.id}, received ${JSON.stringify(countText)}`);
   }
+}
+
+async function pressBackAndWait(): Promise<void> {
   try {
     await device.pressBack();
   } catch {
     adbKeyEvent(4);
   }
   await delay();
+}
+
+async function openSubWikiManager(): Promise<void> {
+  let isVisible = false;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      await waitFor(element(by.id('workspace-subwiki-manager-button'))).toBeVisible().withTimeout(1_000);
+      isVisible = true;
+      break;
+    } catch {
+      await element(by.id('workspace-detail-screen')).swipe('up', 'fast', 0.5);
+      await delay(500);
+    }
+  }
+  if (!isVisible) throw new Error('Sub-wiki manager button did not become visible after scrolling');
+  await element(by.id('workspace-subwiki-manager-button')).tap();
+  await waitForElement(by.id('workspace-subwiki-manager-screen'), 30_000, 'workspace-subwiki-manager-screen');
+}
+
+async function assertImportedWorkspacesHaveNoUnsyncedChanges(): Promise<void> {
+  const mainWiki = selectImportedWikiWorkspace();
+  if (typeof mainWiki?.id !== 'string') throw new Error('No main wiki workspace found.');
+
+  await element(by.id(`workspace-settings-icon-${mainWiki.id}`)).tap();
+  await assertCurrentWorkspaceHasNoUnsyncedChanges(mainWiki);
+
+  const subWikis = readPersistedWikiWorkspaces().filter(
+    workspace => workspace.isSubWiki === true && workspace.mainWikiID === mainWiki.id && typeof workspace.id === 'string',
+  );
+  if (subWikis.length > 0) {
+    await openSubWikiManager();
+    for (const subWiki of subWikis) {
+      const settingsIcon = element(by.id(`workspace-settings-icon-${subWiki.id}`));
+      await waitFor(settingsIcon)
+        .toBeVisible()
+        .whileElement(by.id('workspace-list'))
+        .scroll(200, 'down');
+      await settingsIcon.tap();
+      await assertCurrentWorkspaceHasNoUnsyncedChanges(subWiki);
+      await pressBackAndWait();
+      await waitForElement(by.id('workspace-subwiki-manager-screen'), 30_000, 'workspace-subwiki-manager-screen');
+    }
+    await pressBackAndWait();
+  }
+  await pressBackAndWait();
 }
 
 Then('the mock server git working tree contains {string}', { timeout: 10_000 }, (expectedName: string) => {
@@ -485,6 +547,6 @@ Given('the imported mock server wiki has a synced tiddler {string} in shared his
   await delay(5_000);
   await tapSyncButtonForImportedWiki();
   await waitForSyncSuccess();
-  await assertWorkspaceHasNoUnsyncedChanges();
+  await assertImportedWorkspacesHaveNoUnsyncedChanges();
   assertMockServerGitWorkingTreeContains(title);
 });

--- a/scripts/buildWikiTemplateZip.mjs
+++ b/scripts/buildWikiTemplateZip.mjs
@@ -27,13 +27,11 @@ const outDir = resolve(projectRoot, 'assets');
 const outZip = resolve(outDir, 'wiki-template.zip');
 
 const INITIAL_COMMIT_MESSAGE = 'Initial Commit with TidGi Mobile';
-const MOBILE_GIT_ATTRIBUTES = '* text=auto eol=lf\n';
 
 // Mirrors ensureGitConfigForMobile() in src/services/GitService/index.ts
 const MOBILE_GIT_CONFIG = [
   ['protocol.version', '0'],
   ['core.autocrlf', 'false'],
-  ['core.eol', 'lf'],
   ['pack.window', '2'],
   ['pack.depth', '0'],
   ['pack.windowmemory', String(5 * 1024 * 1024)],
@@ -120,9 +118,6 @@ function initMobileGitRepo(stagingDir) {
   for (const [key, value] of MOBILE_GIT_CONFIG) {
     execSync(`git config ${key} ${value}`, { cwd: stagingDir, stdio: 'inherit' });
   }
-
-  mkdirSync(join(stagingDir, '.git', 'info'), { recursive: true });
-  writeFileSync(join(stagingDir, '.git', 'info', 'attributes'), MOBILE_GIT_ATTRIBUTES, 'utf8');
 
   execSync('git add -A', { cwd: stagingDir, stdio: 'inherit' });
   execSync(`git commit -m "${INITIAL_COMMIT_MESSAGE}"`, { cwd: stagingDir, stdio: 'inherit', env: gitEnv });

--- a/src/components/WorkspaceList.tsx
+++ b/src/components/WorkspaceList.tsx
@@ -232,6 +232,7 @@ export const WorkspaceList: React.FC<WorkspaceListProps> = ({
       {reorderable
         ? (
           <ReorderableList
+            testID='workspace-list'
             data={workspacesList}
             renderItem={({ item }) => (
               <ReorderableWorkspaceListItem
@@ -251,6 +252,7 @@ export const WorkspaceList: React.FC<WorkspaceListProps> = ({
         )
         : (
           <FlatList
+            testID='workspace-list'
             data={workspacesList}
             keyExtractor={item => item.id}
             renderItem={({ item }) => (

--- a/src/pages/Importer/Index.tsx
+++ b/src/pages/Importer/Index.tsx
@@ -28,14 +28,9 @@ function areStringArraysEqual(arrayA: string[], arrayB: string[]): boolean {
   return true;
 }
 
-const Container = styled.ScrollView.attrs({
-  contentContainerStyle: {
-    flexGrow: 1,
-    padding: 20,
-  },
-  keyboardShouldPersistTaps: 'handled',
-})`
+const Container = styled.ScrollView`
   flex: 1;
+  padding: 20px;
 `;
 const ImportWikiButton = styled(Button)`
   margin-top: 20px;
@@ -572,7 +567,7 @@ export const Importer: FC<StackScreenProps<RootStackParameterList, 'Importer'>> 
   const isLocalTemplate = typeof route.params.localTemplateAsset === 'string';
 
   return (
-    <Container testID='importer-screen'>
+    <Container testID='importer-screen' keyboardShouldPersistTaps='handled'>
       {/* Hide server config if is importing from template, for simplicity for new users. */}
       {!isLocalTemplate && autoStartImport !== true && importStatus === 'idle' && serverConfigs}
       {!isLocalTemplate && importStatus === 'idle' && !qrScannerOpen && qrData && createdHtmlWorkspace === undefined && (

--- a/src/pages/Importer/Index.tsx
+++ b/src/pages/Importer/Index.tsx
@@ -28,11 +28,14 @@ function areStringArraysEqual(arrayA: string[], arrayB: string[]): boolean {
   return true;
 }
 
-const Container = styled.View`
+const Container = styled.ScrollView.attrs({
+  contentContainerStyle: {
+    flexGrow: 1,
+    padding: 20,
+  },
+  keyboardShouldPersistTaps: 'handled',
+})`
   flex: 1;
-  padding: 20px;
-  height: 100%;
-  overflow-y: scroll;
 `;
 const ImportWikiButton = styled(Button)`
   margin-top: 20px;

--- a/src/pages/Workspace/WorkspaceDetailPage.tsx
+++ b/src/pages/Workspace/WorkspaceDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native';
 import { StackScreenProps } from '@react-navigation/stack';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -6,7 +7,7 @@ import { styled } from 'styled-components/native';
 import { useShallow } from 'zustand/react/shallow';
 import type { RootStackParameterList } from '../../App';
 import { LogViewerDialog } from '../../components/LogViewerDialog';
-import { gitGetAheadCommitCount } from '../../services/GitService';
+import { gitGetUnsyncedCommitCount } from '../../services/GitService';
 import { IWikiWorkspace, useWorkspaceStore } from '../../store/workspace';
 import { deleteWikiFile } from '../Config/Developer/useClearAllWikiData';
 import { PageContainer, useSyncableWorkspace, useWorkspaceTitle } from './shared';
@@ -17,15 +18,14 @@ const ActionButton = styled(Button)`
   border-radius: 8px;
 `;
 
-const getAheadCommitCount = gitGetAheadCommitCount as (workspace: IWikiWorkspace) => Promise<number>;
-
 export function WorkspaceDetailPage({ route, navigation }: StackScreenProps<RootStackParameterList, 'WorkspaceDetail'>): JSX.Element {
   const { t } = useTranslation();
+  const isFocused = useIsFocused();
   const wiki = useSyncableWorkspace(route.params.id);
   // Combine multiple selector calls into a single useShallow call
   const [removeWorkspace] = useWorkspaceStore(useShallow(state => [state.remove]));
   const allWorkspaces = useWorkspaceStore(useShallow(state => state.workspaces));
-  const [pendingCommitCount, setPendingCommitCount] = useState(0);
+  const [pendingChangeCount, setPendingChangeCount] = useState<number>();
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
   const [deleteSubWorkspacesTogether, setDeleteSubWorkspacesTogether] = useState(false);
   const [workspaceLogVisible, setWorkspaceLogVisible] = useState(false);
@@ -39,14 +39,23 @@ export function WorkspaceDetailPage({ route, navigation }: StackScreenProps<Root
 
   const wikiId = wiki?.id;
   useEffect(() => {
-    if (wikiId === undefined || wiki?.type !== 'wiki') return;
+    setPendingChangeCount(undefined);
+    if (!isFocused || wikiId === undefined || wiki?.type !== 'wiki') return;
+    let cancelled = false;
     const timeout = setTimeout(() => {
-      void getAheadCommitCount(wiki).then(setPendingCommitCount);
+      void gitGetUnsyncedCommitCount(wiki, { ignoreDeferredScan: true, throwOnError: true })
+        .then((count) => {
+          if (!cancelled) setPendingChangeCount(count);
+        })
+        .catch((error: unknown) => {
+          console.error(`Failed to refresh workspace unsynced count: ${(error as Error).message}`);
+        });
     }, 1_500);
     return () => {
+      cancelled = true;
       clearTimeout(timeout);
     };
-  }, [wiki, wikiId]);
+  }, [isFocused, wiki, wikiId]);
 
   if (!wiki) {
     return (
@@ -58,7 +67,9 @@ export function WorkspaceDetailPage({ route, navigation }: StackScreenProps<Root
 
   return (
     <PageContainer testID='workspace-detail-screen'>
-      {isFolderWiki && <Text variant='bodySmall' testID='workspace-unsynced-count'>{t('Sync.UnsyncedCommitCount', { count: pendingCommitCount })}</Text>}
+      {isFolderWiki && pendingChangeCount !== undefined && (
+        <Text variant='bodySmall' testID='workspace-unsynced-count'>{t('Sync.UnsyncedCommitCount', { count: pendingChangeCount })}</Text>
+      )}
 
       <ActionButton
         testID='workspace-sync-button'

--- a/src/pages/Workspace/WorkspaceDetailPage.tsx
+++ b/src/pages/Workspace/WorkspaceDetailPage.tsx
@@ -48,7 +48,8 @@ export function WorkspaceDetailPage({ route, navigation }: StackScreenProps<Root
           if (!cancelled) setPendingChangeCount(count);
         })
         .catch((error: unknown) => {
-          console.error(`Failed to refresh workspace unsynced count: ${(error as Error).message}`);
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`Failed to refresh workspace unsynced count: ${message}`);
         });
     }, 1_500);
     return () => {

--- a/src/pages/Workspace/WorkspaceDetailPage.tsx
+++ b/src/pages/Workspace/WorkspaceDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useIsFocused } from '@react-navigation/native';
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Checkbox, Dialog, Portal, Text } from 'react-native-paper';
 import { styled } from 'styled-components/native';
@@ -34,16 +34,20 @@ export function WorkspaceDetailPage({ route, navigation }: StackScreenProps<Root
   );
   const isFolderWiki = wiki?.type === 'wiki';
   const canDeleteSubWorkspacesTogether = isFolderWiki && wiki.isSubWiki !== true && subWorkspaces.length > 0;
+  const wikiReference = useRef(wiki);
+  wikiReference.current = wiki;
 
   useWorkspaceTitle({ route, navigation } as StackScreenProps<RootStackParameterList, keyof RootStackParameterList>, wiki, t('WorkspaceSettings.Title'));
 
   const wikiId = wiki?.id;
   useEffect(() => {
     setPendingChangeCount(undefined);
-    if (!isFocused || wikiId === undefined || wiki?.type !== 'wiki') return;
+    if (!isFocused || wikiId === undefined || !isFolderWiki) return;
     let cancelled = false;
     const timeout = setTimeout(() => {
-      void gitGetUnsyncedCommitCount(wiki, { ignoreDeferredScan: true, throwOnError: true })
+      const currentWiki = wikiReference.current;
+      if (currentWiki?.type !== 'wiki' || currentWiki.id !== wikiId) return;
+      void gitGetUnsyncedCommitCount(currentWiki, { ignoreDeferredScan: true, throwOnError: true })
         .then((count) => {
           if (!cancelled) setPendingChangeCount(count);
         })
@@ -56,7 +60,7 @@ export function WorkspaceDetailPage({ route, navigation }: StackScreenProps<Root
       cancelled = true;
       clearTimeout(timeout);
     };
-  }, [isFocused, wiki, wikiId]);
+  }, [isFolderWiki, isFocused, wikiId]);
 
   if (!wiki) {
     return (
@@ -126,6 +130,7 @@ export function WorkspaceDetailPage({ route, navigation }: StackScreenProps<Root
       )}
       {isFolderWiki && wiki.isSubWiki !== true && (
         <ActionButton
+          testID='workspace-subwiki-manager-button'
           mode='outlined'
           icon='file-tree'
           onPress={() => {

--- a/src/pages/Workspace/WorkspaceSubWikiManagerPage.tsx
+++ b/src/pages/Workspace/WorkspaceSubWikiManagerPage.tsx
@@ -20,7 +20,7 @@ export function WorkspaceSubWikiManagerPage({ route, navigation }: StackScreenPr
   }
 
   return (
-    <SubWikiPageContainer>
+    <SubWikiPageContainer testID='workspace-subwiki-manager-screen'>
       <SubWikiManager
         workspace={wiki}
         onPressWorkspace={(subWorkspace) => {

--- a/src/services/GitService/__tests__/mobileGitSetup.test.ts
+++ b/src/services/GitService/__tests__/mobileGitSetup.test.ts
@@ -1,0 +1,24 @@
+import { removeLegacyMobileLfAttributesRule } from '../mobileGitSetup';
+
+describe('removeLegacyMobileLfAttributesRule', () => {
+  it('removes the legacy rule without changing user-authored LF lines', () => {
+    expect(removeLegacyMobileLfAttributesRule(
+      '*.png -text\n* text=auto eol=lf\n*.sh text eol=lf\n',
+    )).toBe('*.png -text\n*.sh text eol=lf\n');
+  });
+
+  it('preserves CRLF and mixed line endings on unrelated rules', () => {
+    expect(removeLegacyMobileLfAttributesRule(
+      '*.png -text\r\n  * text=auto eol=lf  \r\n*.sh text eol=lf\n*.bat text eol=crlf\r\n',
+    )).toBe('*.png -text\r\n*.sh text eol=lf\n*.bat text eol=crlf\r\n');
+  });
+
+  it('does not remove repository rules that are not the exact legacy rule', () => {
+    const content = '* text=auto\n/docs/** text eol=lf\n';
+    expect(removeLegacyMobileLfAttributesRule(content)).toBe(content);
+  });
+
+  it('removes a legacy-only file with no trailing newline', () => {
+    expect(removeLegacyMobileLfAttributesRule('* text=auto eol=lf')).toBe('');
+  });
+});

--- a/src/services/GitService/index.ts
+++ b/src/services/GitService/index.ts
@@ -710,8 +710,9 @@ export async function ensureGitConfigForMobile(
   if (gitCheckoutPolicyCache.hasConfig(directory)) return;
   const settings: Array<[string, string | null, string, string]> = [
     ['protocol', null, 'version', '0'],
+    // Do not infer text conversions from the mobile platform. Repository-owned
+    // .gitattributes remains authoritative for paths that declare an EOL rule.
     ['core', null, 'autocrlf', 'false'],
-    ['core', null, 'eol', 'lf'],
     // Disable delta compression entirely — mobile only pushes small changes,
     // and delta search over large object stores causes OOM.
     ['pack', null, 'window', '2'],

--- a/src/services/GitService/index.ts
+++ b/src/services/GitService/index.ts
@@ -1216,8 +1216,13 @@ export async function gitGetUnsyncedCommitCount(
   ) return 0;
   try {
     const aheadCount = await gitGetAheadCommitCount(workspace, options);
-    const hasUncommittedChanges = await gitHasChanges(workspace);
-    return aheadCount + (hasUncommittedChanges ? 1 : 0);
+    try {
+      const hasUncommittedChanges = await gitHasChanges(workspace);
+      return aheadCount + (hasUncommittedChanges ? 1 : 0);
+    } catch (error) {
+      if (options.throwOnError === true) throw error;
+      return aheadCount;
+    }
   } catch (error) {
     console.error(`Failed to get unsynced commit count: ${(error as Error).message}`);
     if (options.throwOnError === true) throw error;

--- a/src/services/GitService/index.ts
+++ b/src/services/GitService/index.ts
@@ -89,7 +89,7 @@ const CLONE_RETRY_DELAY_MS = 3_000;
 const MAX_SAFE_PACK_BYTES = 80 * 1024 * 1024;
 const DEFAULT_TIDGI_TOKEN_AUTH_HEADER_PREFIX = 'x-tidgi-auth-token';
 const DEFAULT_TIDGI_USER_NAME = 'TidGi User';
-const LOCAL_GIT_INFO_ATTRIBUTES_RULE = '* text=auto eol=lf';
+const LEGACY_LOCAL_GIT_INFO_ATTRIBUTES_RULE = '* text=auto eol=lf';
 
 // ── Helpers ────────────────────────────────────────────────────────
 
@@ -238,19 +238,11 @@ function deduplicateNFC(
 
 const IMAGE_FILE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg']);
 const TEXT_FILE_EXTENSIONS = new Set(['.tid', '.js', '.ts', '.tsx', '.json', '.md', '.txt', '.css', '.html', '.xml', '.yml', '.yaml', '.meta']);
-const LINE_ENDING_NORMALIZATION_EXTENSIONS = new Set([...TEXT_FILE_EXTENSIONS, '.info', '.ini', '.svg', '.toml']);
-const LINE_ENDING_NORMALIZATION_FILE_NAMES = new Set(['.editorconfig', '.gitattributes', '.gitignore', '.gitmodules']);
 
 function getFileExtension(filePath: string): string {
   const dotIndex = filePath.lastIndexOf('.');
   if (dotIndex < 0) return '';
   return filePath.slice(dotIndex).toLowerCase();
-}
-
-function getFileName(filePath: string): string {
-  const normalizedPath = filePath.replace(/\\/g, '/');
-  const slashIndex = normalizedPath.lastIndexOf('/');
-  return slashIndex >= 0 ? normalizedPath.slice(slashIndex + 1) : normalizedPath;
 }
 
 function getImageMimeType(filePath: string): string {
@@ -278,12 +270,6 @@ function isTextFile(filePath: string): boolean {
 
 function isImageFile(filePath: string): boolean {
   return IMAGE_FILE_EXTENSIONS.has(getFileExtension(filePath));
-}
-
-function shouldNormalizeLineEndings(filePath: string): boolean {
-  const fileName = getFileName(filePath).toLowerCase();
-  if (LINE_ENDING_NORMALIZATION_FILE_NAMES.has(fileName)) return true;
-  return LINE_ENDING_NORMALIZATION_EXTENSIONS.has(getFileExtension(fileName));
 }
 
 function normalizeLineEndingsToLF(content: string): string {
@@ -318,68 +304,6 @@ async function ensureDirectoryExists(path: string): Promise<void> {
   if (!info.exists) {
     await FileSystemLegacy.makeDirectoryAsync(toFileUri(path), { intermediates: true });
   }
-}
-
-async function listAllFilesInternal(directory: string): Promise<string[]> {
-  const results: string[] = [];
-  const directoryUri = `${toFileUri(directory).replace(/\/+$/, '')}/`;
-
-  let entries: string[] = [];
-  try {
-    entries = await FileSystemLegacy.readDirectoryAsync(directoryUri);
-  } catch {
-    return results;
-  }
-
-  for (const entry of entries) {
-    if (entry === '.git') continue;
-    const entryUri = `${directoryUri}${entry}`;
-    const info = await FileSystemLegacy.getInfoAsync(entryUri);
-    if (!info.exists) continue;
-    if (info.isDirectory) {
-      results.push(...await listAllFilesInternal(toPlainPath(entryUri)));
-      continue;
-    }
-    results.push(toPlainPath(entryUri));
-  }
-
-  return results;
-}
-
-async function listAllRepositoryFiles(directory: string): Promise<string[]> {
-  if (isExternalPath(directory)) {
-    const plainDirectory = directory.replace(/\/+$/, '');
-    const relativePaths = await ExternalStorage.readDirRecursive(plainDirectory).catch(() => [] as string[]);
-    return relativePaths
-      .filter(relativePath => !relativePath.startsWith('.git/'))
-      .map(relativePath => `${plainDirectory}/${relativePath}`);
-  }
-
-  return listAllFilesInternal(directory);
-}
-
-async function normalizeRepositoryTextFilesToLF(directory: string): Promise<number> {
-  const filePaths = await listAllRepositoryFiles(directory);
-  let normalizedCount = 0;
-
-  for (const filePath of filePaths) {
-    if (!shouldNormalizeLineEndings(filePath)) continue;
-
-    let content: string;
-    try {
-      content = await readUtf8File(filePath);
-    } catch {
-      continue;
-    }
-
-    const normalizedContent = normalizeLineEndingsToLF(content);
-    if (normalizedContent === content) continue;
-
-    await writeUtf8File(filePath, normalizedContent);
-    normalizedCount += 1;
-  }
-
-  return normalizedCount;
 }
 
 /**
@@ -437,11 +361,16 @@ async function ensureGitAttributesForMobile(
     existing = '';
   }
 
-  const existingRules = existing.split('\n').map(line => line.trim());
-  if (!existingRules.includes(LOCAL_GIT_INFO_ATTRIBUTES_RULE)) {
-    const updated = existing === '' || existing.endsWith('\n')
-      ? `${existing}${LOCAL_GIT_INFO_ATTRIBUTES_RULE}\n`
-      : `${existing}\n${LOCAL_GIT_INFO_ATTRIBUTES_RULE}\n`;
+  // Older mobile versions injected a global LF rule here. Native checkout
+  // writes Git blobs byte-for-byte and does not run Git's smudge filters, so
+  // that rule makes historical CRLF blobs appear modified even when their
+  // visible contents are unchanged. Remove the legacy rule and preserve any
+  // user-authored local attributes.
+  const updated = existing
+    .split('\n')
+    .filter(line => line.trim() !== LEGACY_LOCAL_GIT_INFO_ATTRIBUTES_RULE)
+    .join('\n');
+  if (updated !== existing) {
     await writeUtf8File(attributesPath, updated);
   }
 
@@ -451,16 +380,10 @@ async function ensureGitAttributesForMobile(
 
 async function ensureGitTextCheckoutPolicy(
   directory: string,
-  options: { normalizeWorkingTreeTextFiles?: boolean } = {},
   onProgress?: (phase: string, loaded: number, total: number) => void,
 ): Promise<void> {
   await ensureGitAttributesForMobile(directory, onProgress);
   await ensureGitConfigForMobile(directory, onProgress);
-
-  if (options.normalizeWorkingTreeTextFiles === true) {
-    const normalizedCount = await normalizeRepositoryTextFilesToLF(directory);
-    console.log(`[ensureGitTextCheckoutPolicy] Normalized ${normalizedCount} files to LF in ${directory}`);
-  }
 }
 
 // ── Clone ──────────────────────────────────────────────────────────
@@ -490,7 +413,7 @@ export async function gitCloneToDirectory(
       if (didArchive) {
         console.log('[gitClone] Fast archive clone succeeded');
         onProgress?.('Writing files to disk…', 0, 1);
-        await ensureGitTextCheckoutPolicy(directory, {}, onProgress);
+        await ensureGitTextCheckoutPolicy(directory, onProgress);
         onProgress?.('Writing files to disk…', 1, 1);
         return;
       }
@@ -548,7 +471,7 @@ export async function gitCloneToDirectory(
       await gitCloneNative(remote, url, directory, onProgress);
       onProgress?.('Writing files to disk…', 0, 1);
       try {
-        await ensureGitTextCheckoutPolicy(directory, {}, onProgress);
+        await ensureGitTextCheckoutPolicy(directory, onProgress);
       } catch (policyError) {
         console.warn('[gitClone] Failed to apply local git text checkout policy after native clone:', (policyError as Error).message);
       }
@@ -689,7 +612,7 @@ async function tryArchiveClone(
   } catch { /* ignore */ }
 
   await configureGitRemote(directory, remote);
-  await ensureGitTextCheckoutPolicy(directory, { normalizeWorkingTreeTextFiles: true });
+  await ensureGitTextCheckoutPolicy(directory);
 
   console.log('[archiveClone] Rebuilding .git/index…');
   onProgress?.('Building git index…', 0, 0);

--- a/src/services/GitService/index.ts
+++ b/src/services/GitService/index.ts
@@ -10,6 +10,7 @@ import * as FileSystemLegacy from 'expo-file-system/legacy';
 import { ExternalStorage, toPlainPath } from 'expo-tiddlywiki-filesystem-android-external-storage';
 import pTimeout from 'p-timeout';
 import { IWikiWorkspace } from '../../store/workspace';
+import { removeLegacyMobileLfAttributesRule } from './mobileGitSetup';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -89,7 +90,6 @@ const CLONE_RETRY_DELAY_MS = 3_000;
 const MAX_SAFE_PACK_BYTES = 80 * 1024 * 1024;
 const DEFAULT_TIDGI_TOKEN_AUTH_HEADER_PREFIX = 'x-tidgi-auth-token';
 const DEFAULT_TIDGI_USER_NAME = 'TidGi User';
-const LEGACY_LOCAL_GIT_INFO_ATTRIBUTES_RULE = '* text=auto eol=lf';
 
 // ── Helpers ────────────────────────────────────────────────────────
 
@@ -272,10 +272,6 @@ function isImageFile(filePath: string): boolean {
   return IMAGE_FILE_EXTENSIONS.has(getFileExtension(filePath));
 }
 
-function normalizeLineEndingsToLF(content: string): string {
-  return content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-}
-
 async function readUtf8File(path: string): Promise<string> {
   if (isExternalPath(path)) {
     return ExternalStorage.readFileUtf8(path);
@@ -306,21 +302,17 @@ async function ensureDirectoryExists(path: string): Promise<void> {
   }
 }
 
-/**
- * Tracks directories where mobile git attributes/config have already been
- * applied this session. Encapsulated as a class to avoid module-level mutable
- * state spread across loose functions.
- */
-class GitCheckoutPolicyCache {
-  readonly #attributesApplied = new Set<string>();
+/** Tracks repositories where one-time mobile Git setup has run this session. */
+class MobileGitSetupCache {
+  readonly #legacyAttributesMigrated = new Set<string>();
   readonly #configApplied = new Set<string>();
 
-  hasAttributes(directory: string): boolean {
-    return this.#attributesApplied.has(directory);
+  hasMigratedLegacyAttributes(directory: string): boolean {
+    return this.#legacyAttributesMigrated.has(directory);
   }
 
-  markAttributesApplied(directory: string): void {
-    this.#attributesApplied.add(directory);
+  markLegacyAttributesMigrated(directory: string): void {
+    this.#legacyAttributesMigrated.add(directory);
   }
 
   hasConfig(directory: string): boolean {
@@ -332,33 +324,32 @@ class GitCheckoutPolicyCache {
   }
 
   clear(directory: string): void {
-    this.#attributesApplied.delete(directory);
+    this.#legacyAttributesMigrated.delete(directory);
     this.#configApplied.delete(directory);
   }
 }
 
-const gitCheckoutPolicyCache = new GitCheckoutPolicyCache();
-const clearGitTextCheckoutPolicyCache = (directory: string) => {
-  gitCheckoutPolicyCache.clear(directory);
+const mobileGitSetupCache = new MobileGitSetupCache();
+const clearMobileGitSetupCache = (directory: string) => {
+  mobileGitSetupCache.clear(directory);
 };
 
-async function ensureGitAttributesForMobile(
+async function migrateLegacyMobileGitAttributes(
   directory: string,
   onProgress?: (phase: string, loaded: number, total: number) => void,
 ): Promise<void> {
-  if (gitCheckoutPolicyCache.hasAttributes(directory)) return;
+  if (mobileGitSetupCache.hasMigratedLegacyAttributes(directory)) return;
 
-  onProgress?.('Applying git attributes…', 0, 1);
+  onProgress?.('Migrating git attributes…', 0, 1);
 
-  const infoDirectory = `${directory}/.git/info`;
-  const attributesPath = `${infoDirectory}/attributes`;
-  await ensureDirectoryExists(infoDirectory);
+  const attributesPath = `${directory}/.git/info/attributes`;
 
   let existing = '';
   try {
-    existing = normalizeLineEndingsToLF(await readUtf8File(attributesPath));
+    existing = await readUtf8File(attributesPath);
   } catch {
-    existing = '';
+    // Most repositories do not have local attributes. There is nothing to
+    // create now that mobile no longer owns an EOL policy.
   }
 
   // Older mobile versions injected a global LF rule here. Native checkout
@@ -366,23 +357,20 @@ async function ensureGitAttributesForMobile(
   // that rule makes historical CRLF blobs appear modified even when their
   // visible contents are unchanged. Remove the legacy rule and preserve any
   // user-authored local attributes.
-  const updated = existing
-    .split('\n')
-    .filter(line => line.trim() !== LEGACY_LOCAL_GIT_INFO_ATTRIBUTES_RULE)
-    .join('\n');
+  const updated = removeLegacyMobileLfAttributesRule(existing);
   if (updated !== existing) {
     await writeUtf8File(attributesPath, updated);
   }
 
-  gitCheckoutPolicyCache.markAttributesApplied(directory);
-  onProgress?.('Applying git attributes…', 1, 1);
+  mobileGitSetupCache.markLegacyAttributesMigrated(directory);
+  onProgress?.('Migrating git attributes…', 1, 1);
 }
 
-async function ensureGitTextCheckoutPolicy(
+async function ensureMobileGitSetup(
   directory: string,
   onProgress?: (phase: string, loaded: number, total: number) => void,
 ): Promise<void> {
-  await ensureGitAttributesForMobile(directory, onProgress);
+  await migrateLegacyMobileGitAttributes(directory, onProgress);
   await ensureGitConfigForMobile(directory, onProgress);
 }
 
@@ -420,7 +408,7 @@ export async function gitCloneToDirectory(
     : `${baseUrl}/tw-mobile-sync/git/${remote.workspaceId}`;
   const directory = toPlainPath(directoryInput);
 
-  clearGitTextCheckoutPolicyCache(directory);
+  clearMobileGitSetupCache(directory);
 
   console.log('Git clone URL:', url);
   console.log('Git clone directory:', directory);
@@ -433,13 +421,13 @@ export async function gitCloneToDirectory(
       if (didArchive) {
         console.log('[gitClone] Fast archive clone succeeded');
         onProgress?.('Writing files to disk…', 0, 1);
-        await ensureGitTextCheckoutPolicy(directory, onProgress);
+        await ensureMobileGitSetup(directory, onProgress);
         onProgress?.('Writing files to disk…', 1, 1);
         return;
       }
-      clearGitTextCheckoutPolicyCache(directory);
+      clearMobileGitSetupCache(directory);
     } catch (error) {
-      clearGitTextCheckoutPolicyCache(directory);
+      clearMobileGitSetupCache(directory);
       const message = (error as Error).message;
       if (isConnectionAbortError(message)) {
         console.warn('[gitClone] Archive download interrupted:', message);
@@ -491,9 +479,9 @@ export async function gitCloneToDirectory(
       await gitCloneNative(remote, url, directory, onProgress);
       onProgress?.('Writing files to disk…', 0, 1);
       try {
-        await ensureGitTextCheckoutPolicy(directory, onProgress);
-      } catch (policyError) {
-        console.warn('[gitClone] Failed to apply local git text checkout policy after native clone:', (policyError as Error).message);
+        await ensureMobileGitSetup(directory, onProgress);
+      } catch (setupError) {
+        console.warn('[gitClone] Failed to apply mobile Git setup after native clone:', (setupError as Error).message);
       }
       onProgress?.('Writing files to disk…', 1, 1);
       return;
@@ -632,7 +620,7 @@ async function tryArchiveClone(
   } catch { /* ignore */ }
 
   await configureGitRemote(directory, remote);
-  await ensureGitTextCheckoutPolicy(directory);
+  await ensureMobileGitSetup(directory);
 
   console.log('[archiveClone] Rebuilding .git/index…');
   onProgress?.('Building git index…', 0, 0);
@@ -649,7 +637,7 @@ async function tryArchiveClone(
       throw new Error(`buildGitIndex failed: ${indexResult.error ?? 'unknown'}`);
     }
   } catch (error) {
-    console.warn('[archiveClone] Failed to rebuild .git/index, falling back to native clone:', (error as Error).message);
+    console.warn('[archiveClone] Failed to prepare archive repository, falling back to native clone:', (error as Error).message);
     // Clean up the partially-extracted directory so the fallback clone can proceed.
     try {
       if (isExternalPath(directory)) {
@@ -728,7 +716,7 @@ export async function ensureGitConfigForMobile(
   directory: string,
   onProgress?: (phase: string, loaded: number, total: number) => void,
 ): Promise<void> {
-  if (gitCheckoutPolicyCache.hasConfig(directory)) return;
+  if (mobileGitSetupCache.hasConfig(directory)) return;
   const settings: Array<[string, string | null, string, string]> = [
     ['protocol', null, 'version', '0'],
     // Do not infer text conversions from the mobile platform. Repository-owned
@@ -757,7 +745,7 @@ export async function ensureGitConfigForMobile(
     onProgress?.('Applying git configuration…', index + 1, settings.length);
   }
   console.log('[ensureGitConfig] Applied mobile git config settings');
-  gitCheckoutPolicyCache.markConfigApplied(directory);
+  mobileGitSetupCache.markConfigApplied(directory);
 }
 
 export async function gitPushToIncoming(
@@ -837,7 +825,7 @@ export async function gitFetchAndReset(
   );
   const headBefore = headBeforeResult.ok ? (headBeforeResult.oid ?? '') : '';
 
-  await ensureGitTextCheckoutPolicy(directory);
+  await ensureMobileGitSetup(directory);
 
   // Request a bundle from the desktop containing commits we don't have
   const bundleUrl = `${remote.baseUrl}/tw-mobile-sync/git/${remote.workspaceId}/create-bundle`;
@@ -1011,9 +999,23 @@ export async function gitGetRemoteOids(workspace: IWikiWorkspace, depth = 300): 
   }
 }
 
-export async function gitGetAheadCommitCount(workspace: IWikiWorkspace): Promise<number> {
+interface IGitStatusScanOptions {
+  /** Run an explicit user-requested scan even during the post-import quiet period. */
+  ignoreDeferredScan?: boolean;
+  /** Surface native failures instead of treating an unavailable count as zero. */
+  throwOnError?: boolean;
+}
+
+export async function gitGetAheadCommitCount(
+  workspace: IWikiWorkspace,
+  options: IGitStatusScanOptions = {},
+): Promise<number> {
   const directory = toPlainPath(workspace.wikiFolderLocation);
-  if (typeof workspace.deferStatusScanUntil === 'number' && Date.now() < workspace.deferStatusScanUntil) return 0;
+  if (
+    options.ignoreDeferredScan !== true &&
+    typeof workspace.deferStatusScanUntil === 'number' &&
+    Date.now() < workspace.deferStatusScanUntil
+  ) return 0;
   try {
     const branch = await getCurrentBranch(directory);
     const remoteReference = `origin/${branch}`;
@@ -1041,6 +1043,9 @@ export async function gitGetAheadCommitCount(workspace: IWikiWorkspace): Promise
     );
     if (!localResult.ok || !localResult.commits) {
       localResult = parseNativeResult(await ExternalStorage.gitLog(directory, 'HEAD', LOG_DEPTH));
+    }
+    if ((!localResult.ok || !localResult.commits) && options.throwOnError === true) {
+      throw new Error('Could not read local commit history');
     }
     const localCommits = localResult.ok ? (localResult.commits ?? []) : [];
 
@@ -1071,6 +1076,9 @@ export async function gitGetAheadCommitCount(workspace: IWikiWorkspace): Promise
     const remoteResult = parseNativeResult<{ ok: boolean; commits?: Array<{ oid: string }> }>(
       await ExternalStorage.gitLog(directory, remoteReference, LOG_DEPTH),
     );
+    if (!remoteResult.ok && options.throwOnError === true && workspace.syncedServers.length > 0) {
+      throw new Error(`Could not read ${remoteReference} commit history`);
+    }
     const remoteCommits = remoteResult.ok ? (remoteResult.commits ?? []) : [];
     const remoteOids = new Set(remoteCommits.map(c => c.oid));
     let aheadCount = 0;
@@ -1081,6 +1089,7 @@ export async function gitGetAheadCommitCount(workspace: IWikiWorkspace): Promise
     return aheadCount;
   } catch (error) {
     console.error(`Failed to get ahead commit count: ${(error as Error).message}`);
+    if (options.throwOnError === true) throw error;
     return 0;
   }
 }
@@ -1195,14 +1204,22 @@ export async function gitHasChanges(workspace: IWikiWorkspace): Promise<boolean>
 
 // ── Unsynced commit count ──────────────────────────────────────────
 
-export async function gitGetUnsyncedCommitCount(workspace: IWikiWorkspace): Promise<number> {
-  if (typeof workspace.deferStatusScanUntil === 'number' && Date.now() < workspace.deferStatusScanUntil) return 0;
+export async function gitGetUnsyncedCommitCount(
+  workspace: IWikiWorkspace,
+  options: IGitStatusScanOptions = {},
+): Promise<number> {
+  if (
+    options.ignoreDeferredScan !== true &&
+    typeof workspace.deferStatusScanUntil === 'number' &&
+    Date.now() < workspace.deferStatusScanUntil
+  ) return 0;
   try {
-    const aheadCount = await gitGetAheadCommitCount(workspace);
-    const hasUncommittedChanges = await gitHasChanges(workspace).catch(() => false);
+    const aheadCount = await gitGetAheadCommitCount(workspace, options);
+    const hasUncommittedChanges = await gitHasChanges(workspace);
     return aheadCount + (hasUncommittedChanges ? 1 : 0);
   } catch (error) {
     console.error(`Failed to get unsynced commit count: ${(error as Error).message}`);
+    if (options.throwOnError === true) throw error;
     return 0;
   }
 }
@@ -1260,7 +1277,7 @@ export async function gitInit(workspace: IWikiWorkspace): Promise<void> {
     const resultJson = await ExternalStorage.gitInit(directory, 'main');
     const result = parseNativeResult<{ ok: boolean; error?: string }>(resultJson);
     if (!result.ok) throw new Error(result.error ?? 'Unknown init error');
-    await ensureGitTextCheckoutPolicy(directory);
+    await ensureMobileGitSetup(directory);
     console.log(`Initialized git repository at ${directory}`);
   } catch (error) {
     console.error(`Git init failed: ${(error as Error).message}`);

--- a/src/services/GitService/index.ts
+++ b/src/services/GitService/index.ts
@@ -386,6 +386,26 @@ async function ensureGitTextCheckoutPolicy(
   await ensureGitConfigForMobile(directory, onProgress);
 }
 
+/**
+ * A full archive is a snapshot of Desktop's HEAD, but the copied
+ * remote-tracking refs can lag when Desktop auto-commits pending files just
+ * before creating that archive. Record the snapshot HEAD as the remote state
+ * observed by this clone so a fresh import is not incorrectly shown as ahead.
+ */
+async function alignArchiveRemoteTrackingReference(directory: string): Promise<void> {
+  const branch = await getCurrentBranch(directory);
+  const headResult = parseNativeResult<{ ok: boolean; oid?: string; error?: string }>(
+    await ExternalStorage.gitResolveRef(directory, 'HEAD'),
+  );
+  if (!headResult.ok || typeof headResult.oid !== 'string' || headResult.oid.length === 0) {
+    throw new Error(headResult.error ?? 'Could not resolve archive HEAD');
+  }
+
+  const remoteReferencePath = `${directory}/.git/refs/remotes/origin/${branch}`;
+  await ensureDirectoryExists(remoteReferencePath.slice(0, remoteReferencePath.lastIndexOf('/')));
+  await writeUtf8File(remoteReferencePath, `${headResult.oid}\n`);
+}
+
 // ── Clone ──────────────────────────────────────────────────────────
 
 export async function gitCloneToDirectory(
@@ -620,6 +640,7 @@ async function tryArchiveClone(
     const indexResult = parseNativeResult<{ ok: boolean; entries?: number; error?: string }>(await ExternalStorage.buildGitIndex(directory));
     if (indexResult.ok) {
       console.log(`[archiveClone] .git/index rebuilt: ${indexResult.entries} entries`);
+      await alignArchiveRemoteTrackingReference(directory);
     } else {
       // If the index cannot be rebuilt, the working tree and HEAD will be out of sync:
       // git status will report every file as a modification.

--- a/src/services/GitService/index.ts
+++ b/src/services/GitService/index.ts
@@ -1011,6 +1011,7 @@ export async function gitGetAheadCommitCount(
   options: IGitStatusScanOptions = {},
 ): Promise<number> {
   const directory = toPlainPath(workspace.wikiFolderLocation);
+  if (workspace.syncedServers.length === 0) return 0;
   if (
     options.ignoreDeferredScan !== true &&
     typeof workspace.deferStatusScanUntil === 'number' &&
@@ -1076,7 +1077,7 @@ export async function gitGetAheadCommitCount(
     const remoteResult = parseNativeResult<{ ok: boolean; commits?: Array<{ oid: string }> }>(
       await ExternalStorage.gitLog(directory, remoteReference, LOG_DEPTH),
     );
-    if (!remoteResult.ok && options.throwOnError === true && workspace.syncedServers.length > 0) {
+    if (!remoteResult.ok && options.throwOnError === true) {
       throw new Error(`Could not read ${remoteReference} commit history`);
     }
     const remoteCommits = remoteResult.ok ? (remoteResult.commits ?? []) : [];

--- a/src/services/GitService/mobileGitSetup.ts
+++ b/src/services/GitService/mobileGitSetup.ts
@@ -1,0 +1,15 @@
+export const LEGACY_MOBILE_LF_ATTRIBUTES_RULE = '* text=auto eol=lf';
+
+/**
+ * Remove the local attributes rule injected by older TidGi Mobile releases.
+ *
+ * Preserve every other byte, including the file's original line endings.
+ * `.git/info/attributes` may contain user-authored rules, so migration must not
+ * normalize or reconstruct unrelated lines.
+ */
+export function removeLegacyMobileLfAttributesRule(content: string): string {
+  const linesWithEndings = content.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g) ?? [];
+  return linesWithEndings
+    .filter(line => line.replace(/[\r\n]+$/, '').trim() !== LEGACY_MOBILE_LF_ATTRIBUTES_RULE)
+    .join('');
+}

--- a/src/services/WikiImportService/gitCloneCache.ts
+++ b/src/services/WikiImportService/gitCloneCache.ts
@@ -1,4 +1,4 @@
-import { Paths } from 'expo-file-system';
+import { Directory, Paths } from 'expo-file-system';
 import * as FileSystemLegacy from 'expo-file-system/legacy';
 import { ExternalStorage, toPlainPath } from 'expo-tiddlywiki-filesystem-android-external-storage';
 import { buildGitCloneCacheDirectory } from './gitCloneCacheUtilities';
@@ -45,74 +45,23 @@ async function ensureDirectory(path: string): Promise<void> {
 
 /**
  * Best-effort copy of a prepared wiki directory into the git clone cache (internal storage only).
+ *
+ * Keep this copy entirely native. Reading each file as base64 crosses the
+ * native/JS bridge and requires a contiguous allocation roughly 4/3 the size
+ * of the largest Git pack. Real wikis commonly have 100–200 MB pack files,
+ * which exceeds Android's 256 MB Java heap and can terminate the app after an
+ * otherwise-successful import.
  */
 export async function updateGitCloneCache(cacheDirectory: string, sourceDirectory: string): Promise<void> {
   const sourcePlain = toPlainPath(sourceDirectory).replace(/\/+$/, '');
   const cachePlain = toPlainPath(cacheDirectory).replace(/\/+$/, '');
-
-  let relativePaths: string[];
-  if (sourcePlain.startsWith('/storage/') || sourcePlain.startsWith('/sdcard/')) {
-    relativePaths = await ExternalStorage.readDirRecursive(sourcePlain).catch(() => [] as string[]);
-  } else {
-    relativePaths = await listInternalFilesRecursive(sourcePlain);
-  }
-
-  if (relativePaths.length === 0) return;
+  const source = new Directory(toFileUri(sourcePlain));
+  if (!source.exists) return;
 
   const cacheInfo = await FileSystemLegacy.getInfoAsync(toFileUri(cachePlain));
   if (cacheInfo.exists) {
     await FileSystemLegacy.deleteAsync(toFileUri(cachePlain), { idempotent: true });
   }
-  await ensureDirectory(cachePlain);
-
-  for (const relativePath of relativePaths) {
-    let content: string;
-    const sourceFilePlain = `${sourcePlain}/${relativePath}`;
-    try {
-      if (sourcePlain.startsWith('/storage/') || sourcePlain.startsWith('/sdcard/')) {
-        content = await ExternalStorage.readFileBase64(sourceFilePlain);
-      } else {
-        content = await FileSystemLegacy.readAsStringAsync(toFileUri(sourceFilePlain), {
-          encoding: FileSystemLegacy.EncodingType.Base64,
-        });
-      }
-    } catch {
-      continue;
-    }
-
-    const destinationPlain = `${cachePlain}/${relativePath}`;
-    await ensureDirectory(getParentDirectory(destinationPlain));
-    await FileSystemLegacy.writeAsStringAsync(toFileUri(destinationPlain), content, {
-      encoding: FileSystemLegacy.EncodingType.Base64,
-    });
-  }
-}
-
-async function listInternalFilesRecursive(directoryPlain: string): Promise<string[]> {
-  const directoryUri = toFileUri(directoryPlain);
-  const results: string[] = [];
-
-  async function walk(currentUri: string, relativePrefix: string): Promise<void> {
-    let entries: string[] = [];
-    try {
-      entries = await FileSystemLegacy.readDirectoryAsync(currentUri.endsWith('/') ? currentUri : `${currentUri}/`);
-    } catch {
-      return;
-    }
-
-    for (const entry of entries) {
-      const entryUri = `${currentUri.replace(/\/$/, '')}/${entry}`;
-      const relativePath = relativePrefix.length > 0 ? `${relativePrefix}/${entry}` : entry;
-      const info = await FileSystemLegacy.getInfoAsync(entryUri);
-      if (!info.exists) continue;
-      if (info.isDirectory) {
-        await walk(entryUri, relativePath);
-      } else {
-        results.push(relativePath);
-      }
-    }
-  }
-
-  await walk(directoryUri, '');
-  return results;
+  await ensureDirectory(getParentDirectory(cachePlain));
+  source.copy(new Directory(toFileUri(cachePlain)));
 }

--- a/src/services/WikiImportService/gitCloneCache.ts
+++ b/src/services/WikiImportService/gitCloneCache.ts
@@ -55,9 +55,12 @@ async function ensureDirectory(path: string): Promise<void> {
 export async function updateGitCloneCache(cacheDirectory: string, sourceDirectory: string): Promise<void> {
   const sourcePlain = toPlainPath(sourceDirectory).replace(/\/+$/, '');
   const cachePlain = toPlainPath(cacheDirectory).replace(/\/+$/, '');
-  const source = new Directory(toFileUri(sourcePlain));
-  if (!source.exists) return;
+  const sourceInfo = sourcePlain.startsWith('/storage/') || sourcePlain.startsWith('/sdcard/')
+    ? await ExternalStorage.getInfo(sourcePlain)
+    : await FileSystemLegacy.getInfoAsync(toFileUri(sourcePlain));
+  if (!sourceInfo.exists) return;
 
+  const source = new Directory(toFileUri(sourcePlain));
   const cacheInfo = await FileSystemLegacy.getInfoAsync(toFileUri(cachePlain));
   if (cacheInfo.exists) {
     await FileSystemLegacy.deleteAsync(toFileUri(cachePlain), { idempotent: true });


### PR DESCRIPTION
## Summary

- preserve repository line endings during archive imports and migrate away the legacy mobile-only `* text=auto eol=lf` rule
- copy clone caches with the native filesystem API instead of Base64 across the JS bridge, avoiding Android heap exhaustion on large Git packs
- align archive `origin/<branch>` with the snapshot HEAD so a fresh Desktop import is not falsely shown as ahead
- make the multi-workspace import confirmation screen scrollable
- make the Desktop-sync E2E assertion wait for a completed Git scan and verify both uncommitted files and ahead commits

## Root cause and device verification

On a physical Android 12 device, the old cache copy attempted a 267,071,340-byte contiguous Java allocation against a roughly 256 MB heap. The native-copy path imported all three real workspaces, including a 2,332,349,440-byte private wiki archive, without OOM; its 12,863-entry Git index completed successfully.

The three apparently modified Markdown files were CRLF blobs in HEAD. Previous mobile code rewrote them to LF after extraction. With this change, each device worktree hash matched HEAD and the workspace had no uncommitted files.

The private wiki's apparent pending push was a separate ref bug: Desktop auto-committed immediately before serving the archive, while the copied `origin/master` still pointed to its parent. Archive setup now records the served snapshot HEAD as the mobile clone's remote-tracking state.

## LF regression audit

The forced LF policy was added by PR #99, commit `1368a3642`, after issue #98 attributed an all-files-dirty import to EOL conversion without byte-level diagnostics or a regression test. A stronger recorded cause was commit `caa92caa`: failed archive index construction left an empty `.git/index`, which makes every tracked file appear modified. That index-failure cleanup and native-clone fallback remains intact.

Desktop full archives are produced by `git archive ... HEAD`, so they contain committed blob bytes rather than the Windows working tree. Android `buildGitIndex` uses JGit `reset --mixed HEAD`, which rebuilds the index without checking out or rewriting the worktree. Native JGit clone likewise creates checkout and index together. Mobile therefore should not impose a repository-wide EOL policy; repository-owned `.gitattributes` remains authoritative and `core.autocrlf=false` prevents platform guessing.

The E2E baseline now contains an explicitly tracked CRLF Markdown blob. A fresh archive import must preserve it and pass a strict native Git status scan. The legacy `.git/info/attributes` migration also has unit coverage proving that it removes only TidGi's exact old rule while byte-preserving every user-authored rule and its original line endings.

## Checks

- TypeScript `tsc --noEmit --skipLibCheck`
- ESLint on all changed source files
- 4 focused LF migration unit tests
- Cucumber dry run: 8 mobile-sync scenarios / 62 steps all defined
- `git diff --check`
- earlier real-device three-workspace import and direct ref/blob inspection

The full Jest command currently cannot load two unrelated existing suites because the local dependency tree is missing `@babel/runtime/helpers/interopRequireDefault`; the new suite and the existing QR suite pass. The pre-push hook also reruns `pnpm install`, which fails on the existing ignored-builds workspace policy, so the verified direct checks above were used before pushing.